### PR TITLE
Add encrypted web-based text editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/app.py
+++ b/app.py
@@ -1,0 +1,80 @@
+import base64
+import hashlib
+import sqlite3
+from flask import Flask, render_template, request, jsonify
+from cryptography.fernet import Fernet, InvalidToken
+
+app = Flask(__name__)
+DB_PATH = 'documents.db'
+
+
+def get_db():
+    conn = sqlite3.connect(DB_PATH)
+    conn.execute(
+        'CREATE TABLE IF NOT EXISTS documents (filename TEXT PRIMARY KEY, content BLOB)'
+    )
+    return conn
+
+
+def derive_key(filename: str, password: str) -> bytes:
+    """Derive a Fernet key from the filename and password."""
+    digest = hashlib.sha256((filename + password).encode()).digest()
+    return base64.urlsafe_b64encode(digest)
+
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+
+@app.post('/api/open')
+def open_doc():
+    data = request.get_json()
+    filename = data.get('filename', '')
+    password = data.get('password', '')
+    if not filename or not password:
+        return jsonify({'error': 'Filename and password required'}), 400
+
+    conn = get_db()
+    cur = conn.cursor()
+    cur.execute('SELECT content FROM documents WHERE filename=?', (filename,))
+    row = cur.fetchone()
+    conn.close()
+    if not row:
+        # New document
+        return jsonify({'content': ''})
+    key = derive_key(filename, password)
+    f = Fernet(key)
+    try:
+        decrypted = f.decrypt(row[0]).decode()
+    except InvalidToken:
+        return jsonify({'error': 'Invalid file name or password'}), 403
+    return jsonify({'content': decrypted})
+
+
+@app.post('/api/save')
+def save_doc():
+    data = request.get_json()
+    filename = data.get('filename', '')
+    password = data.get('password', '')
+    content = data.get('content', '')
+    if not filename or not password:
+        return jsonify({'error': 'Filename and password required'}), 400
+
+    key = derive_key(filename, password)
+    f = Fernet(key)
+    encrypted = f.encrypt(content.encode())
+
+    conn = get_db()
+    cur = conn.cursor()
+    cur.execute(
+        'INSERT OR REPLACE INTO documents (filename, content) VALUES (?, ?)',
+        (filename, encrypted),
+    )
+    conn.commit()
+    conn.close()
+    return jsonify({'status': 'saved'})
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,24 @@
-Simple encoded text editor
+# Secure Text Editor
+
+A basic privacy‑focused text editor that stores documents encoded in a SQLite database. Each document is protected by a file name and password pair.
+
+## Features
+- Create or open documents using a file name and password.
+- Text is encrypted and saved in a local SQLite database.
+- Save current document or save under a new file name and password.
+- Basic editing features with a plain text area.
+
+## Usage
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the application:
+   ```bash
+   python app.py
+   ```
+3. In your browser open `http://localhost:5000`.
+4. Enter a file name and password to create or open a document. After opening, the fields are cleared and the editor becomes available.
+5. Use **Save** to store changes or **Save As** to save under a different name and password.
+
+The database file `documents.db` is created in the working directory. Without the correct file name and password a document cannot be opened.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+cryptography

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,58 @@
+let currentFilename = null;
+let currentPassword = null;
+
+document.getElementById('open-btn').addEventListener('click', async () => {
+    const filename = document.getElementById('filename').value;
+    const password = document.getElementById('password').value;
+    const resp = await fetch('/api/open', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ filename, password })
+    });
+    const data = await resp.json();
+    if (!resp.ok) {
+        alert(data.error);
+        return;
+    }
+    currentFilename = filename;
+    currentPassword = password;
+    document.getElementById('filename').value = '';
+    document.getElementById('password').value = '';
+    document.getElementById('auth').style.display = 'none';
+    document.getElementById('editor').style.display = 'block';
+    document.getElementById('text').value = data.content || '';
+});
+
+document.getElementById('save-btn').addEventListener('click', () => save(currentFilename, currentPassword));
+
+document.getElementById('saveas-btn').addEventListener('click', async () => {
+    const filename = prompt('File name:');
+    const password = prompt('Password:');
+    if (!filename || !password) return;
+    currentFilename = filename;
+    currentPassword = password;
+    await save(filename, password);
+});
+
+document.getElementById('new-btn').addEventListener('click', () => {
+    currentFilename = null;
+    currentPassword = null;
+    document.getElementById('text').value = '';
+    document.getElementById('editor').style.display = 'none';
+    document.getElementById('auth').style.display = 'block';
+});
+
+async function save(filename, password) {
+    const content = document.getElementById('text').value;
+    const resp = await fetch('/api/save', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ filename, password, content })
+    });
+    const data = await resp.json();
+    if (!resp.ok) {
+        alert(data.error);
+    } else {
+        alert('Saved');
+    }
+}

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,3 @@
+body { font-family: sans-serif; margin: 20px; }
+#controls { margin-bottom: 10px; }
+textarea { width: 100%; height: 60vh; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>Secure Text Editor</title>
+    <link rel="stylesheet" href="/static/style.css" />
+</head>
+<body>
+    <div id="auth">
+        <input id="filename" placeholder="File name" />
+        <input id="password" placeholder="Password" type="password" />
+        <button id="open-btn">Open / Create</button>
+    </div>
+    <div id="editor" style="display:none;">
+        <div id="controls">
+            <button id="save-btn">Save</button>
+            <button id="saveas-btn">Save As</button>
+            <button id="new-btn">New</button>
+        </div>
+        <textarea id="text" rows="20" cols="80"></textarea>
+    </div>
+    <script src="/static/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Implement Flask application storing documents encrypted in SQLite database
- Add HTML and JavaScript interface with filename/password authentication, save, save-as, and new document functionality
- Document usage and dependencies for running the secure editor

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_6895755d2ea88325b773ab16ed2b6151