### PR TITLE
Use environment variable to control Flask debug mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -103,4 +103,5 @@ def save_doc():
 
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    debug_mode = os.getenv('FLASK_DEBUG', 'false').lower() in ('1', 'true', 't', 'yes')
+    app.run(debug=debug_mode)


### PR DESCRIPTION
## Summary
- Gate Flask debug mode behind the `FLASK_DEBUG` environment variable
- Remove hard-coded `debug=True` from `app.run`

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689581c57a2c832584cd85b45a874a3a